### PR TITLE
FIX: Upgrade Python version for PharmCAT reference update

### DIFF
--- a/pipeline_pharmcat/lambda/updateReferenceFiles/pharmcat.sh
+++ b/pipeline_pharmcat/lambda/updateReferenceFiles/pharmcat.sh
@@ -9,7 +9,7 @@ PHARMCAT_VERSION="__PHARMCAT_VERSION__"
 PHARMCAT_VERSION_NO="__PHARMCAT_VERSION_NO__"
 PHARMGKB_ID="__PHARMGKB_ID__"
 REFERENCE_LOCATION="__REFERENCE_LOCATION__"
- 
+
 dnf install -y \
     git \
     bzip2 \
@@ -23,12 +23,13 @@ dnf install -y \
     xz-devel \
     curl-devel \
     java-17-amazon-corretto \
-    python3 \
-    python3-pip
+    python3.12 \
+    python3.12-pip \
+    jq
 
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 unzip awscliv2.zip
-sudo ./aws/install
+./aws/install
 export PATH=/usr/local/bin:$PATH
 
 wget "https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.tar.bz2" \
@@ -38,7 +39,7 @@ wget "https://github.com/samtools/bcftools/releases/download/1.21/bcftools-1.21.
     && make \
     && make install \
     && cd ..
-    
+
 wget "https://github.com/samtools/htslib/releases/download/1.21/htslib-1.21.tar.bz2" \
     && tar -xvjf htslib-1.21.tar.bz2 \
     && cd htslib-1.21 \
@@ -50,13 +51,13 @@ wget "https://github.com/samtools/htslib/releases/download/1.21/htslib-1.21.tar.
 wget "https://github.com/PharmGKB/PharmCAT/releases/download/$PHARMCAT_VERSION/pharmcat-preprocessor-$PHARMCAT_VERSION_NO.tar.gz"
 mkdir -p preprocessor
 tar -xvf pharmcat-preprocessor-$PHARMCAT_VERSION_NO.tar.gz && rm pharmcat-preprocessor-$PHARMCAT_VERSION_NO.tar.gz
-cd preprocessor 
+cd preprocessor
 
-pip install -r requirements.txt
+pip3.12 install -r requirements.txt
 
 # download reference files using pharmcat
 CURRENT_DIR=$(pwd)
-CURDIR="$CURRENT_DIR" python3 -c 'import os, pcat; pcat.download_pharmcat_accessory_files(os.environ["CURDIR"]); pcat.prep_pharmcat_positions()'
+CURDIR="$CURRENT_DIR" python3.12 -c 'import os, pcat; pcat.download_pharmcat_accessory_files(os.environ["CURDIR"]); pcat.prep_pharmcat_positions()'
 
 cd ..
 


### PR DESCRIPTION
* Newer versions of PharmCAT rely on syntax not supported by Python's default version on AWS EC2 (3.9)
* Explicitly install and run with 3.12 for compatibility