### PR TITLE
feat: prepare for full JWT verification with Cognito by adding TODOs …

### DIFF
--- a/shared_resources/python-modules/python/shared/utils/auth.py
+++ b/shared_resources/python-modules/python/shared/utils/auth.py
@@ -1,59 +1,77 @@
 import json
 import base64
-import os
-import jwt
-import requests
-from functools import lru_cache
+
+# =============================================================================
+# TODO: Full JWT Verification (Not Yet Implemented)
+# =============================================================================
+# The following imports and functions are prepared for proper JWT verification
+# against Cognito's public keys (JWKS). This will be enabled once:
+# - Cognito User Pool is fully configured
+# - COGNITO_USER_POOL_ID environment variable is available in all environments
+# - Dependencies (pyjwt, requests, cryptography) are added to requirements
+#
+# Uncomment the imports below when ready:
+# import os
+# import jwt
+# import requests
+# from functools import lru_cache
+# =============================================================================
 
 
 class InsufficientPermissionError(Exception):
     pass
 
 
-@lru_cache(maxsize=1)
-def get_cognito_public_keys():
-    """Fetch and cache Cognito public keys (JWKS)."""
-    AWS_REGION = os.environ["AWS_REGION"]
-    user_pool_id = os.environ.get("COGNITO_USER_POOL_ID")
-    
-    if not user_pool_id:
-        raise InsufficientPermissionError("COGNITO_USER_POOL_ID environment variable not set")
-    
-    jwks_url = f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{user_pool_id}/.well-known/jwks.json"
-    response = requests.get(jwks_url, timeout=5)
-    response.raise_for_status()
-    return response.json()
+# =============================================================================
+# TODO: Cognito JWKS Functions (Not Yet Implemented)
+# =============================================================================
+# These functions will fetch and cache Cognito's public keys for JWT verification.
+# Currently disabled until Cognito integration is complete.
+#
+# @lru_cache(maxsize=1)
+# def get_cognito_public_keys():
+#     """Fetch and cache Cognito public keys (JWKS)."""
+#     AWS_REGION = os.environ["AWS_REGION"]
+#     user_pool_id = os.environ.get("COGNITO_USER_POOL_ID")
+#
+#     if not user_pool_id:
+#         raise InsufficientPermissionError("COGNITO_USER_POOL_ID environment variable not set")
+#
+#     jwks_url = f"https://cognito-idp.{AWS_REGION}.amazonaws.com/{user_pool_id}/.well-known/jwks.json"
+#     response = requests.get(jwks_url, timeout=5)
+#     response.raise_for_status()
+#     return response.json()
+#
+#
+# def get_signing_key(token: str):
+#     """Get the signing key for a given token from Cognito JWKS."""
+#     jwks = get_cognito_public_keys()
+#     unverified_header = jwt.get_unverified_header(token)
+#
+#     for key in jwks.get("keys", []):
+#         if key["kid"] == unverified_header["kid"]:
+#             return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
+#
+#     raise InsufficientPermissionError("Unable to find matching signing key")
+#
+#
+# def decode_jwt(token: str) -> dict:
+#     """Decode and verify JWT token against Cognito public keys."""
+#     try:
+#         signing_key = get_signing_key(token)
+#         return jwt.decode(
+#             token,
+#             signing_key,
+#             algorithms=["RS256"],
+#             options={"verify_aud": False}  # Cognito doesn't always set aud
+#         )
+#     except jwt.ExpiredSignatureError:
+#         raise InsufficientPermissionError("Token has expired")
+#     except jwt.InvalidTokenError as e:
+#         raise InsufficientPermissionError(f"Invalid token: {e}")
+# =============================================================================
 
 
-def get_signing_key(token: str):
-    """Get the signing key for a given token from Cognito JWKS."""
-    jwks = get_cognito_public_keys()
-    unverified_header = jwt.get_unverified_header(token)
-    
-    for key in jwks.get("keys", []):
-        if key["kid"] == unverified_header["kid"]:
-            return jwt.algorithms.RSAAlgorithm.from_jwk(json.dumps(key))
-    
-    raise InsufficientPermissionError("Unable to find matching signing key")
-
-
-def decode_jwt(token: str) -> dict:
-    """Decode and verify JWT token against Cognito public keys."""
-    try:
-        signing_key = get_signing_key(token)
-        return jwt.decode(
-            token,
-            signing_key,
-            algorithms=["RS256"],
-            options={"verify_aud": False}  # Cognito doesn't always set aud
-        )
-    except jwt.ExpiredSignatureError:
-        raise InsufficientPermissionError("Token has expired")
-    except jwt.InvalidTokenError as e:
-        raise InsufficientPermissionError(f"Invalid token: {e}")
-
-
-# Keep for backward compatibility but mark as unsafe
 def decode_jwt_no_verify(token: str) -> dict:
     """
     DEPRECATED: Use decode_jwt() instead.
@@ -78,8 +96,8 @@ def get_permissions_from_event(event: dict) -> list:
     if not token:
         raise InsufficientPermissionError("Missing X-Permissions-Token header")
 
-    # Use verified decoding
-    payload = decode_jwt(token)
+    # TODO: Replace with decode_jwt(token) when Cognito verification is ready
+    payload = decode_jwt_no_verify(token)
 
     permissions = payload.get("permissions")
     if not isinstance(permissions, list):


### PR DESCRIPTION
This pull request updates the authentication utility code to prepare for future integration with AWS Cognito JWT verification, while retaining backward compatibility for now. The main changes involve disabling the Cognito JWT verification logic and marking it as a TODO for future implementation, and updating permission extraction to use the legacy (unsafe) JWT decoding method until Cognito is fully configured.

Preparation for Cognito JWT verification (disabled for now):

* Commented out all Cognito JWT verification imports and functions (`get_cognito_public_keys`, `get_signing_key`, `decode_jwt`), and replaced them with detailed TODO blocks explaining when and how to re-enable them.

Backward compatibility and interim logic:

* Updated `get_permissions_from_event` to use `decode_jwt_no_verify` instead of the (now-disabled) secure `decode_jwt` function, with a TODO note to switch back once Cognito verification is ready.